### PR TITLE
feat(frontend): implement base api service

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -43,3 +43,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+*.g.dart
+*.freezed.dart

--- a/frontend/analysis_options.yaml
+++ b/frontend/analysis_options.yaml
@@ -9,6 +9,13 @@
 # packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
+analyzer: 
+  exclude: 
+    - "**/*.g.dart"  # Exclude generated files from analysis
+    - "**/*.freezed.dart"  # Exclude Freezed generated files from analysis
+  errors:
+    invalid_annotation_target: ignore  # Ignore invalid annotation target errors
+
 linter:
   # The lint rules applied to this project can be customized in the
   # section below to disable rules from the `package:flutter_lints/flutter.yaml`

--- a/frontend/lib/api/api.dart
+++ b/frontend/lib/api/api.dart
@@ -1,0 +1,24 @@
+// Core API exports
+export '../core/api/api_client.dart';
+export '../core/api/api_exception.dart';
+export '../core/api/api_response.dart';
+export '../core/api/services_interfaces.dart';
+
+// Services exports
+export 'services/user_service.dart';
+export 'services/physiological_data_service.dart';
+export 'services/anxiety_event_service.dart';
+export 'services/session_service.dart';
+export 'services/device_service.dart';
+export 'services/notification_service.dart';
+
+// Dependency Injection exports
+export '../core/di/service_locator.dart';
+
+// Models exports (re-export for convenience)
+export '../models/user/user.dart';
+export '../models/anxiety_event/anxiety_event.dart';
+export '../models/physiological_data/physiological_data.dart';
+export '../models/session/session.dart';
+export '../models/dispositivo/dispositivo.dart';
+export '../models/notification/notification_model.dart';

--- a/frontend/lib/api/services/anxiety_event_service.dart
+++ b/frontend/lib/api/services/anxiety_event_service.dart
@@ -1,0 +1,162 @@
+import 'package:dio/dio.dart';
+import '../../models/anxiety_event/anxiety_event.dart';
+import '../../core/api/api_client.dart';
+import '../../core/api/api_exception.dart';
+import '../../core/api/api_response.dart';
+import '../../core/api/services_interfaces.dart';
+
+/// Implementación concreta del servicio de eventos de ansiedad
+class AnxietyEventService implements IAnxietyEventService {
+  final ApiClient _apiClient;
+
+  AnxietyEventService(this._apiClient);
+
+  @override
+  Future<PaginatedResponse<AnxietyEvent>> getAnxietyEvents({
+    int page = 1,
+    int pageSize = 20,
+    int? usuarioId,
+    int? sesionId,
+    AnxietyLevel? nivelAnsiedad,
+    DateTime? startDate,
+    DateTime? endDate,
+    bool? resuelto,
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{
+        'page': page,
+        'page_size': pageSize,
+        if (usuarioId != null) 'usuario_id': usuarioId,
+        if (sesionId != null) 'sesion_id': sesionId,
+        if (nivelAnsiedad != null) 'nivel_ansiedad': nivelAnsiedad.name,
+        if (startDate != null) 'start_date': startDate.toIso8601String(),
+        if (endDate != null) 'end_date': endDate.toIso8601String(),
+        if (resuelto != null) 'resuelto': resuelto,
+      };
+
+      final response = await _apiClient.client.get(
+        '/anxiety-events',
+        queryParameters: queryParams,
+      );
+
+      return PaginatedResponse.fromJson(
+        response.data,
+        (json) => AnxietyEvent.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<AnxietyEvent>> getAnxietyEventById(int id) async {
+    try {
+      final response = await _apiClient.client.get('/anxiety-events/$id');
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => AnxietyEvent.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<AnxietyEvent>> createAnxietyEvent({
+    required int usuarioId,
+    required int sesionId,
+    required DateTime timestamp,
+    required AnxietyLevel nivelAnsiedad,
+    required int bpmMomento,
+    required int spo2Momento,
+    required double temperaturaMomento,
+    required int duracionMinutos,
+    required Map<String, dynamic> factoresDetectados,
+    required String accionTomada,
+    String? notasUsuario,
+  }) async {
+    try {
+      final response = await _apiClient.client.post(
+        '/anxiety-events',
+        data: {
+          'usuario_id': usuarioId,
+          'sesion_id': sesionId,
+          'timestamp': timestamp.toIso8601String(),
+          'nivel_ansiedad': nivelAnsiedad.name,
+          'bpm_momento': bpmMomento,
+          'spo2_momento': spo2Momento,
+          'temperatura_momento': temperaturaMomento,
+          'duracion_minutos': duracionMinutos,
+          'factores_detectados': factoresDetectados,
+          'accion_tomada': accionTomada,
+          'notas_usuario': notasUsuario ?? '',
+        },
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => AnxietyEvent.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<AnxietyEvent>> updateAnxietyEvent(
+    int id,
+    Map<String, dynamic> data,
+  ) async {
+    try {
+      final response = await _apiClient.client.put(
+        '/anxiety-events/$id',
+        data: data,
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => AnxietyEvent.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<void>> deleteAnxietyEvent(int id) async {
+    try {
+      final response = await _apiClient.client.delete('/anxiety-events/$id');
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => null,
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<AnxietyEvent>> markAsResolved(
+    int id, {
+    String? notasUsuario,
+  }) async {
+    try {
+      final response = await _apiClient.client.patch(
+        '/anxiety-events/$id/resolve',
+        data: {
+          'resuelto': true,
+          if (notasUsuario != null) 'notas_usuario': notasUsuario,
+        },
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => AnxietyEvent.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+}

--- a/frontend/lib/api/services/device_service.dart
+++ b/frontend/lib/api/services/device_service.dart
@@ -1,0 +1,172 @@
+import 'package:dio/dio.dart';
+import '../../models/dispositivo/dispositivo.dart';
+import '../../core/api/api_client.dart';
+import '../../core/api/api_exception.dart';
+import '../../core/api/api_response.dart';
+import '../../core/api/services_interfaces.dart';
+
+/// Implementación concreta del servicio de dispositivos
+class DeviceService implements IDeviceService {
+  final ApiClient _apiClient;
+
+  DeviceService(this._apiClient);
+
+  @override
+  Future<PaginatedResponse<Dispositivo>> getDevices({
+    int page = 1,
+    int pageSize = 20,
+    String? search,
+    bool? activo,
+    int? usuarioAsignado,
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{
+        'page': page,
+        'page_size': pageSize,
+        if (search != null) 'search': search,
+        if (activo != null) 'activo': activo,
+        if (usuarioAsignado != null) 'usuario_asignado': usuarioAsignado,
+      };
+
+      final response = await _apiClient.client.get(
+        '/devices',
+        queryParameters: queryParams,
+      );
+
+      return PaginatedResponse.fromJson(
+        response.data,
+        (json) => Dispositivo.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<Dispositivo>> getDeviceById(int id) async {
+    try {
+      final response = await _apiClient.client.get('/devices/$id');
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => Dispositivo.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<Dispositivo>> createDevice({
+    required String numeroSerie,
+    required String modelo,
+    String? ubicacion,
+  }) async {
+    try {
+      final response = await _apiClient.client.post(
+        '/devices',
+        data: {
+          'numero_serie': numeroSerie,
+          'modelo': modelo,
+          if (ubicacion != null) 'ubicacion': ubicacion,
+        },
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => Dispositivo.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<Dispositivo>> updateDevice(
+    int id,
+    Map<String, dynamic> data,
+  ) async {
+    try {
+      final response = await _apiClient.client.put(
+        '/devices/$id',
+        data: data,
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => Dispositivo.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<void>> deleteDevice(int id) async {
+    try {
+      final response = await _apiClient.client.delete('/devices/$id');
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => null,
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<Dispositivo>> assignDevice({
+    required int deviceId,
+    required int usuarioId,
+  }) async {
+    try {
+      final response = await _apiClient.client.patch(
+        '/devices/$deviceId/assign',
+        data: {
+          'usuario_asignado': usuarioId,
+        },
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => Dispositivo.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<Dispositivo>> unassignDevice(int deviceId) async {
+    try {
+      final response = await _apiClient.client.patch(
+        '/devices/$deviceId/unassign',
+        data: {
+          'usuario_asignado': null,
+        },
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => Dispositivo.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<Map<String, dynamic>>> getDeviceStatus(int id) async {
+    try {
+      final response = await _apiClient.client.get('/devices/$id/status');
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => json as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+}

--- a/frontend/lib/api/services/notification_service.dart
+++ b/frontend/lib/api/services/notification_service.dart
@@ -1,0 +1,140 @@
+import 'package:dio/dio.dart';
+import '../../models/notification/notification_model.dart';
+import '../../core/api/api_client.dart';
+import '../../core/api/api_exception.dart';
+import '../../core/api/api_response.dart';
+import '../../core/api/services_interfaces.dart';
+
+/// Implementación concreta del servicio de notificaciones
+class NotificationService implements INotificationService {
+  final ApiClient _apiClient;
+
+  NotificationService(this._apiClient);
+
+  @override
+  Future<PaginatedResponse<NotificationModel>> getNotifications({
+    int page = 1,
+    int pageSize = 20,
+    int? usuarioId,
+    bool? leida,
+    String? tipo,
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{
+        'page': page,
+        'page_size': pageSize,
+        if (usuarioId != null) 'usuario_id': usuarioId,
+        if (leida != null) 'leida': leida,
+        if (tipo != null) 'tipo': tipo,
+      };
+
+      final response = await _apiClient.client.get(
+        '/notifications',
+        queryParameters: queryParams,
+      );
+
+      return PaginatedResponse.fromJson(
+        response.data,
+        (json) => NotificationModel.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<NotificationModel>> getNotificationById(int id) async {
+    try {
+      final response = await _apiClient.client.get('/notifications/$id');
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => NotificationModel.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<NotificationModel>> createNotification({
+    required int usuarioId,
+    required String titulo,
+    required String mensaje,
+    required String tipo,
+    Map<String, dynamic>? metadatos,
+  }) async {
+    try {
+      final response = await _apiClient.client.post(
+        '/notifications',
+        data: {
+          'usuario_id': usuarioId,
+          'titulo': titulo,
+          'mensaje': mensaje,
+          'tipo': tipo,
+          if (metadatos != null) 'metadatos': metadatos,
+        },
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => NotificationModel.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<NotificationModel>> markAsRead(int id) async {
+    try {
+      final response = await _apiClient.client.patch(
+        '/notifications/$id/read',
+        data: {
+          'leida': true,
+          'fecha_leida': DateTime.now().toIso8601String(),
+        },
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => NotificationModel.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<void>> markAllAsRead(int usuarioId) async {
+    try {
+      final response = await _apiClient.client.patch(
+        '/notifications/mark-all-read',
+        data: {
+          'usuario_id': usuarioId,
+        },
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => null,
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<void>> deleteNotification(int id) async {
+    try {
+      final response = await _apiClient.client.delete('/notifications/$id');
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => null,
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+}

--- a/frontend/lib/api/services/physiological_data_service.dart
+++ b/frontend/lib/api/services/physiological_data_service.dart
@@ -1,0 +1,151 @@
+import 'package:dio/dio.dart';
+import '../../models/physiological_data/physiological_data.dart';
+import '../../core/api/api_client.dart';
+import '../../core/api/api_exception.dart';
+import '../../core/api/api_response.dart';
+import '../../core/api/services_interfaces.dart';
+
+/// Implementación concreta del servicio de datos fisiológicos
+class PhysiologicalDataService implements IPhysiologicalDataService {
+  final ApiClient _apiClient;
+
+  PhysiologicalDataService(this._apiClient);
+
+  @override
+  Future<PaginatedResponse<PhysiologicalData>> getPhysiologicalData({
+    int page = 1,
+    int pageSize = 20,
+    int? usuarioId,
+    int? sesionId,
+    DateTime? startDate,
+    DateTime? endDate,
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{
+        'page': page,
+        'page_size': pageSize,
+        if (usuarioId != null) 'usuario_id': usuarioId,
+        if (sesionId != null) 'sesion_id': sesionId,
+        if (startDate != null) 'start_date': startDate.toIso8601String(),
+        if (endDate != null) 'end_date': endDate.toIso8601String(),
+      };
+
+      final response = await _apiClient.client.get(
+        '/physiological-data',
+        queryParameters: queryParams,
+      );
+
+      return PaginatedResponse.fromJson(
+        response.data,
+        (json) => PhysiologicalData.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<PhysiologicalData>> getPhysiologicalDataById(int id) async {
+    try {
+      final response = await _apiClient.client.get('/physiological-data/$id');
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => PhysiologicalData.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<PhysiologicalData>> createPhysiologicalData({
+    required int sesionId,
+    required int usuarioId,
+    required int pulseraId,
+    required DateTime timestamp,
+    required int bpm,
+    required int spo2,
+    required double temperatura,
+    required int calidadSenal,
+  }) async {
+    try {
+      final response = await _apiClient.client.post(
+        '/physiological-data',
+        data: {
+          'sesion_id': sesionId,
+          'usuario_id': usuarioId,
+          'pulsera_id': pulseraId,
+          'timestamp': timestamp.toIso8601String(),
+          'bpm': bpm,
+          'spo2': spo2,
+          'temperatura': temperatura,
+          'calidad_senal': calidadSenal,
+        },
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => PhysiologicalData.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<Map<String, dynamic>>> getStatistics({
+    required int usuarioId,
+    DateTime? startDate,
+    DateTime? endDate,
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{
+        'usuario_id': usuarioId,
+        if (startDate != null) 'start_date': startDate.toIso8601String(),
+        if (endDate != null) 'end_date': endDate.toIso8601String(),
+      };
+
+      final response = await _apiClient.client.get(
+        '/physiological-data/statistics',
+        queryParameters: queryParams,
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => json as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<List<Map<String, dynamic>>>> getTimeSeriesData({
+    required int usuarioId,
+    required DateTime startDate,
+    required DateTime endDate,
+    String interval = 'hour',
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{
+        'usuario_id': usuarioId,
+        'start_date': startDate.toIso8601String(),
+        'end_date': endDate.toIso8601String(),
+        'interval': interval,
+      };
+
+      final response = await _apiClient.client.get(
+        '/physiological-data/time-series',
+        queryParameters: queryParams,
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => (json as List).cast<Map<String, dynamic>>(),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+}

--- a/frontend/lib/api/services/session_service.dart
+++ b/frontend/lib/api/services/session_service.dart
@@ -1,0 +1,158 @@
+import 'package:dio/dio.dart';
+import '../../models/session/session.dart';
+import '../../core/api/api_client.dart';
+import '../../core/api/api_exception.dart';
+import '../../core/api/api_response.dart';
+import '../../core/api/services_interfaces.dart';
+
+/// Implementación concreta del servicio de sesiones
+class SessionService implements ISessionService {
+  final ApiClient _apiClient;
+
+  SessionService(this._apiClient);
+
+  @override
+  Future<PaginatedResponse<Session>> getSessions({
+    int page = 1,
+    int pageSize = 20,
+    int? usuarioId,
+    bool? activa,
+    DateTime? startDate,
+    DateTime? endDate,
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{
+        'page': page,
+        'page_size': pageSize,
+        if (usuarioId != null) 'usuario_id': usuarioId,
+        if (activa != null) 'activa': activa,
+        if (startDate != null) 'start_date': startDate.toIso8601String(),
+        if (endDate != null) 'end_date': endDate.toIso8601String(),
+      };
+
+      final response = await _apiClient.client.get(
+        '/sessions',
+        queryParameters: queryParams,
+      );
+
+      return PaginatedResponse.fromJson(
+        response.data,
+        (json) => Session.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<Session>> getSessionById(int id) async {
+    try {
+      final response = await _apiClient.client.get('/sessions/$id');
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => Session.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<Session>> createSession({
+    required int usuarioId,
+    required int pulseraId,
+    String? notas,
+  }) async {
+    try {
+      final response = await _apiClient.client.post(
+        '/sessions',
+        data: {
+          'usuario_id': usuarioId,
+          'pulsera_id': pulseraId,
+          if (notas != null) 'notas': notas,
+        },
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => Session.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<Session>> updateSession(
+    int id,
+    Map<String, dynamic> data,
+  ) async {
+    try {
+      final response = await _apiClient.client.put(
+        '/sessions/$id',
+        data: data,
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => Session.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<Session>> endSession(int id) async {
+    try {
+      final response = await _apiClient.client.patch(
+        '/sessions/$id/end',
+        data: {
+          'activa': false,
+          'fecha_fin': DateTime.now().toIso8601String(),
+        },
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => Session.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<void>> deleteSession(int id) async {
+    try {
+      final response = await _apiClient.client.delete('/sessions/$id');
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => null,
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<Session?>> getActiveSession(int usuarioId) async {
+    try {
+      final response = await _apiClient.client.get(
+        '/sessions/active',
+        queryParameters: {'usuario_id': usuarioId},
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => json != null 
+            ? Session.fromJson(json as Map<String, dynamic>)
+            : null,
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+}

--- a/frontend/lib/api/services/user_service.dart
+++ b/frontend/lib/api/services/user_service.dart
@@ -1,0 +1,204 @@
+import 'package:dio/dio.dart';
+import '../../models/user/user.dart';
+import '../../core/api/api_client.dart';
+import '../../core/api/api_exception.dart';
+import '../../core/api/api_response.dart';
+import '../../core/api/services_interfaces.dart';
+
+/// Implementación concreta del servicio de usuarios
+/// Aplica el principio de responsabilidad única (SRP)
+class UserService implements IUserService {
+  final ApiClient _apiClient;
+
+  UserService(this._apiClient);
+
+  @override
+  Future<ApiResponse<Map<String, dynamic>>> login({
+    required String email,
+    required String password,
+  }) async {
+    try {
+      final response = await _apiClient.client.post(
+        '/auth/login',
+        data: {
+          'email': email,
+          'password': password,
+        },
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => json as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<Map<String, dynamic>>> logout() async {
+    try {
+      final response = await _apiClient.client.post('/auth/logout');
+      
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => json as Map<String, dynamic>,
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<User>> register({
+    required String email,
+    required String password,
+    required String nombre,
+    required String apellido,
+    required String tipoUsuario,
+  }) async {
+    try {
+      final response = await _apiClient.client.post(
+        '/auth/register',
+        data: {
+          'email': email,
+          'password': password,
+          'nombre': nombre,
+          'apellido': apellido,
+          'tipo_usuario': tipoUsuario,
+        },
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => User.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<PaginatedResponse<User>> getUsers({
+    int page = 1,
+    int pageSize = 20,
+    String? search,
+    String? tipoUsuario,
+    bool? activo,
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{
+        'page': page,
+        'page_size': pageSize,
+        if (search != null) 'search': search,
+        if (tipoUsuario != null) 'tipo_usuario': tipoUsuario,
+        if (activo != null) 'activo': activo,
+      };
+
+      final response = await _apiClient.client.get(
+        '/users',
+        queryParameters: queryParams,
+      );
+
+      return PaginatedResponse.fromJson(
+        response.data,
+        (json) => User.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<User>> getUserById(int id) async {
+    try {
+      final response = await _apiClient.client.get('/users/$id');
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => User.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<User>> getCurrentUser() async {
+    try {
+      final response = await _apiClient.client.get('/auth/me');
+      
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => User.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<User>> updateUser(int id, Map<String, dynamic> data) async {
+    try {
+      final response = await _apiClient.client.put('/users/$id', data: data);
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => User.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<void>> deleteUser(int id) async {
+    try {
+      final response = await _apiClient.client.delete('/users/$id');
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => null,
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<User>> updateProfile(Map<String, dynamic> data) async {
+    try {
+      final response = await _apiClient.client.put('/users/profile', data: data);
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => User.fromJson(json as Map<String, dynamic>),
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  @override
+  Future<ApiResponse<void>> changePassword({
+    required String currentPassword,
+    required String newPassword,
+  }) async {
+    try {
+      final response = await _apiClient.client.put(
+        '/users/change-password',
+        data: {
+          'current_password': currentPassword,
+          'new_password': newPassword,
+        },
+      );
+
+      return ApiResponse.fromJson(
+        response.data,
+        (json) => null,
+      );
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+}

--- a/frontend/lib/core/api/api_client.dart
+++ b/frontend/lib/core/api/api_client.dart
@@ -1,0 +1,61 @@
+import 'package:dio/dio.dart';
+
+/// Client HTTP configurado para la aplicación
+/// Aplica el principio de responsabilidad única (SRP)
+class ApiClient {
+  static const String _baseUrl = 'http://192.168.1.82:3000/api';
+  static const Duration _connectTimeout = Duration(seconds: 30);
+  static const Duration _receiveTimeout = Duration(seconds: 30);
+
+  late final Dio _dio;
+
+  ApiClient() {
+    _dio = Dio(BaseOptions(
+      baseUrl: _baseUrl,
+      connectTimeout: _connectTimeout,
+      receiveTimeout: _receiveTimeout,
+      contentType: Headers.jsonContentType,
+      responseType: ResponseType.json,
+    ));
+
+    _setupInterceptors();
+  }
+
+  /// Configura los interceptores para logging y manejo de errores
+  void _setupInterceptors() {
+    _dio.interceptors.add(
+      LogInterceptor(
+        requestBody: true,
+        responseBody: true,
+        logPrint: (obj) => print('[API] $obj'),
+      ),
+    );
+
+    _dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          // Aquí se puede agregar el token de autenticación
+          // options.headers['Authorization'] = 'Bearer $token';
+          handler.next(options);
+        },
+        onError: (error, handler) {
+          // Manejo centralizado de errores
+          handler.next(error);
+        },
+      ),
+    );
+  }
+
+  /// Getter para acceder al cliente Dio
+  Dio get client => _dio;
+
+  /// Actualiza el token de autenticación
+  void updateAuthToken(String token) {
+    _dio.options.headers['Authorization'] = 'Bearer $token';
+  }
+
+  /// Remueve el token de autenticación
+  void removeAuthToken() {
+    _dio.options.headers.remove('Authorization');
+  }
+}

--- a/frontend/lib/core/api/api_exception.dart
+++ b/frontend/lib/core/api/api_exception.dart
@@ -1,0 +1,92 @@
+import 'package:dio/dio.dart';
+
+/// Excepción personalizada para errores de la API
+/// Facilita el manejo de errores de manera consistente
+class ApiException implements Exception {
+  final String message;
+  final int? statusCode;
+  final dynamic data;
+
+  const ApiException({
+    required this.message,
+    this.statusCode,
+    this.data,
+  });
+
+  factory ApiException.fromDioError(DioException error) {
+    switch (error.type) {
+      case DioExceptionType.connectionTimeout:
+        return const ApiException(
+          message: 'Tiempo de conexión agotado',
+          statusCode: null,
+        );
+      case DioExceptionType.sendTimeout:
+        return const ApiException(
+          message: 'Tiempo de envío agotado',
+          statusCode: null,
+        );
+      case DioExceptionType.receiveTimeout:
+        return const ApiException(
+          message: 'Tiempo de respuesta agotado',
+          statusCode: null,
+        );
+      case DioExceptionType.badResponse:
+        return ApiException(
+          message: _getErrorMessage(error.response),
+          statusCode: error.response?.statusCode,
+          data: error.response?.data,
+        );
+      case DioExceptionType.cancel:
+        return const ApiException(
+          message: 'Solicitud cancelada',
+          statusCode: null,
+        );
+      case DioExceptionType.connectionError:
+        return const ApiException(
+          message: 'Error de conexión con el servidor',
+          statusCode: null,
+        );
+      default:
+        return const ApiException(
+          message: 'Error desconocido',
+          statusCode: null,
+        );
+    }
+  }
+
+  static String _getErrorMessage(Response? response) {
+    if (response?.data is Map<String, dynamic>) {
+      final data = response!.data as Map<String, dynamic>;
+      
+      // Buscar mensajes de error comunes
+      if (data.containsKey('message')) {
+        return data['message'].toString();
+      }
+      if (data.containsKey('error')) {
+        return data['error'].toString();
+      }
+      if (data.containsKey('detail')) {
+        return data['detail'].toString();
+      }
+    }
+
+    // Mensajes por código de estado HTTP
+    switch (response?.statusCode) {
+      case 400:
+        return 'Solicitud incorrecta';
+      case 401:
+        return 'No autorizado';
+      case 403:
+        return 'Acceso prohibido';
+      case 404:
+        return 'Recurso no encontrado';
+      case 500:
+        return 'Error interno del servidor';
+      default:
+        return 'Error del servidor (${response?.statusCode})';
+    }
+  }
+
+  @override
+  String toString() => 'ApiException: $message';
+}

--- a/frontend/lib/core/api/api_response.dart
+++ b/frontend/lib/core/api/api_response.dart
@@ -1,0 +1,94 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'api_response.freezed.dart';
+part 'api_response.g.dart';
+
+/// Respuesta genérica de la API
+/// Proporciona una estructura consistente para todas las respuestas
+@freezed
+abstract class ApiResponse<T> with _$ApiResponse<T> {
+  const factory ApiResponse({
+    required bool success,
+    T? data,
+    Map<String, dynamic>? error,
+    @JsonKey(name: 'status_code') int? statusCode,
+  }) = _ApiResponse<T>;
+
+  /// Factory method personalizado para manejar la deserialización
+  factory ApiResponse.fromJson(
+    Map<String, dynamic> json,
+    T Function(Object?) fromJsonT,
+  ) {
+    // Determinar si es una respuesta exitosa basándose en la presencia de 'data' vs 'error'
+    final bool isSuccess = json.containsKey('data') && !json.containsKey('error');
+    
+    T? data;
+    if (isSuccess && json['data'] != null) {
+      try {
+        data = fromJsonT(json['data']);
+      } catch (e) {
+        // Si hay error en la deserialización, tratarlo como error
+        return ApiResponse(
+          success: false,
+          data: null,
+          error: {'detail': 'Error deserializando datos: $e'},
+          statusCode: json['status_code'] as int?,
+        );
+      }
+    }
+    
+    return ApiResponse(
+      success: isSuccess,
+      data: data,
+      error: !isSuccess ? json['error'] as Map<String, dynamic>? : null,
+      statusCode: json['status_code'] as int?,
+    );
+  }
+}
+
+extension ApiResponseExtensions<T> on ApiResponse<T> {
+  /// Indica si la respuesta es exitosa y tiene datos
+  bool get isSuccess => success && data != null;
+  
+  /// Indica si la respuesta es de error
+  bool get isError => !success || error != null;
+  
+  /// Obtiene el mensaje de error si existe
+  String? get errorMessage {
+    if (error != null) {
+      if (error!.containsKey('message')) {
+        return error!['message'] as String?;
+      }
+      if (error!.containsKey('detail')) {
+        return error!['detail'] as String?;
+      }
+      if (error!.containsKey('error')) {
+        return error!['error'] as String?;
+      }
+    }
+    return null;
+  }
+  
+  /// Obtiene los datos de forma segura
+  T? get safeData => success ? data : null;
+}
+
+
+/// Respuesta paginada de la API
+@Freezed(genericArgumentFactories: true)
+abstract class PaginatedResponse<T> with _$PaginatedResponse<T> {
+  const factory PaginatedResponse({
+    required List<T> results,
+    required int count,
+    @JsonKey(name: 'next') String? nextUrl,
+    @JsonKey(name: 'previous') String? previousUrl,
+    @JsonKey(name: 'total_pages') int? totalPages,
+    @JsonKey(name: 'current_page') int? currentPage,
+  }) = _PaginatedResponse<T>;
+
+  factory PaginatedResponse.fromJson(
+    Map<String, dynamic> json,
+    T Function(Object?) fromJsonT,
+  ) =>
+      _$PaginatedResponseFromJson(json, fromJsonT);
+}

--- a/frontend/lib/core/api/services_interfaces.dart
+++ b/frontend/lib/core/api/services_interfaces.dart
@@ -1,0 +1,229 @@
+import '../../models/user/user.dart';
+import '../../models/anxiety_event/anxiety_event.dart';
+import '../../models/physiological_data/physiological_data.dart';
+import '../../models/session/session.dart';
+import '../../models/dispositivo/dispositivo.dart';
+import '../../models/notification/notification_model.dart';
+import 'api_response.dart';
+
+/// Interfaz para el servicio de usuarios
+/// Aplicando el principio de inversión de dependencias (DIP)
+abstract class IUserService {
+  /// Autenticación
+  Future<ApiResponse<Map<String, dynamic>>> login({
+    required String email,
+    required String password,
+  });
+
+  Future<ApiResponse<Map<String, dynamic>>> logout();
+
+  Future<ApiResponse<User>> register({
+    required String email,
+    required String password,
+    required String nombre,
+    required String apellido,
+    required String tipoUsuario,
+  });
+
+  /// Gestión de usuarios
+  Future<PaginatedResponse<User>> getUsers({
+    int page = 1,
+    int pageSize = 20,
+    String? search,
+    String? tipoUsuario,
+    bool? activo,
+  });
+
+  Future<ApiResponse<User>> getUserById(int id);
+  Future<ApiResponse<User>> getCurrentUser();
+  Future<ApiResponse<User>> updateUser(int id, Map<String, dynamic> data);
+  Future<ApiResponse<void>> deleteUser(int id);
+
+  /// Perfil
+  Future<ApiResponse<User>> updateProfile(Map<String, dynamic> data);
+  Future<ApiResponse<void>> changePassword({
+    required String currentPassword,
+    required String newPassword,
+  });
+}
+
+/// Interfaz para el servicio de datos fisiológicos
+abstract class IPhysiologicalDataService {
+  /// Obtener datos fisiológicos
+  Future<PaginatedResponse<PhysiologicalData>> getPhysiologicalData({
+    int page = 1,
+    int pageSize = 20,
+    int? usuarioId,
+    int? sesionId,
+    DateTime? startDate,
+    DateTime? endDate,
+  });
+
+  Future<ApiResponse<PhysiologicalData>> getPhysiologicalDataById(int id);
+  
+  /// Crear datos fisiológicos (desde dispositivo IoT)
+  Future<ApiResponse<PhysiologicalData>> createPhysiologicalData({
+    required int sesionId,
+    required int usuarioId,
+    required int pulseraId,
+    required DateTime timestamp,
+    required int bpm,
+    required int spo2,
+    required double temperatura,
+    required int calidadSenal,
+  });
+
+  /// Estadísticas y agregaciones
+  Future<ApiResponse<Map<String, dynamic>>> getStatistics({
+    required int usuarioId,
+    DateTime? startDate,
+    DateTime? endDate,
+  });
+
+  Future<ApiResponse<List<Map<String, dynamic>>>> getTimeSeriesData({
+    required int usuarioId,
+    required DateTime startDate,
+    required DateTime endDate,
+    String interval = 'hour', // hour, day, week
+  });
+}
+
+/// Interfaz para el servicio de eventos de ansiedad
+abstract class IAnxietyEventService {
+  /// Gestión de eventos de ansiedad
+  Future<PaginatedResponse<AnxietyEvent>> getAnxietyEvents({
+    int page = 1,
+    int pageSize = 20,
+    int? usuarioId,
+    int? sesionId,
+    AnxietyLevel? nivelAnsiedad,
+    DateTime? startDate,
+    DateTime? endDate,
+    bool? resuelto,
+  });
+
+  Future<ApiResponse<AnxietyEvent>> getAnxietyEventById(int id);
+  
+  Future<ApiResponse<AnxietyEvent>> createAnxietyEvent({
+    required int usuarioId,
+    required int sesionId,
+    required DateTime timestamp,
+    required AnxietyLevel nivelAnsiedad,
+    required int bpmMomento,
+    required int spo2Momento,
+    required double temperaturaMomento,
+    required int duracionMinutos,
+    required Map<String, dynamic> factoresDetectados,
+    required String accionTomada,
+    String? notasUsuario,
+  });
+
+  Future<ApiResponse<AnxietyEvent>> updateAnxietyEvent(
+    int id,
+    Map<String, dynamic> data,
+  );
+
+  Future<ApiResponse<void>> deleteAnxietyEvent(int id);
+
+  /// Marcar como resuelto
+  Future<ApiResponse<AnxietyEvent>> markAsResolved(
+    int id, {
+    String? notasUsuario,
+  });
+}
+
+/// Interfaz para el servicio de sesiones
+abstract class ISessionService {
+  /// Gestión de sesiones de monitoreo
+  Future<PaginatedResponse<Session>> getSessions({
+    int page = 1,
+    int pageSize = 20,
+    int? usuarioId,
+    bool? activa,
+    DateTime? startDate,
+    DateTime? endDate,
+  });
+
+  Future<ApiResponse<Session>> getSessionById(int id);
+  
+  Future<ApiResponse<Session>> createSession({
+    required int usuarioId,
+    required int pulseraId,
+    String? notas,
+  });
+
+  Future<ApiResponse<Session>> updateSession(
+    int id,
+    Map<String, dynamic> data,
+  );
+
+  Future<ApiResponse<Session>> endSession(int id);
+  Future<ApiResponse<void>> deleteSession(int id);
+
+  /// Sesión activa
+  Future<ApiResponse<Session?>> getActiveSession(int usuarioId);
+}
+
+/// Interfaz para el servicio de dispositivos
+abstract class IDeviceService {
+  /// Gestión de dispositivos (pulseras)
+  Future<PaginatedResponse<Dispositivo>> getDevices({
+    int page = 1,
+    int pageSize = 20,
+    String? search,
+    bool? activo,
+    int? usuarioAsignado,
+  });
+
+  Future<ApiResponse<Dispositivo>> getDeviceById(int id);
+  
+  Future<ApiResponse<Dispositivo>> createDevice({
+    required String numeroSerie,
+    required String modelo,
+    String? ubicacion,
+  });
+
+  Future<ApiResponse<Dispositivo>> updateDevice(
+    int id,
+    Map<String, dynamic> data,
+  );
+
+  Future<ApiResponse<void>> deleteDevice(int id);
+
+  /// Asignación de dispositivos
+  Future<ApiResponse<Dispositivo>> assignDevice({
+    required int deviceId,
+    required int usuarioId,
+  });
+
+  Future<ApiResponse<Dispositivo>> unassignDevice(int deviceId);
+
+  /// Estado del dispositivo
+  Future<ApiResponse<Map<String, dynamic>>> getDeviceStatus(int id);
+}
+
+/// Interfaz para el servicio de notificaciones
+abstract class INotificationService {
+  /// Gestión de notificaciones
+  Future<PaginatedResponse<NotificationModel>> getNotifications({
+    int page = 1,
+    int pageSize = 20,
+    int? usuarioId,
+    bool? leida,
+    String? tipo,
+  });
+
+  Future<ApiResponse<NotificationModel>> getNotificationById(int id);
+  
+  Future<ApiResponse<NotificationModel>> createNotification({
+    required int usuarioId,
+    required String titulo,
+    required String mensaje,
+    required String tipo,
+    Map<String, dynamic>? metadatos,
+  });
+
+  Future<ApiResponse<NotificationModel>> markAsRead(int id);
+  Future<ApiResponse<void>> markAllAsRead(int usuarioId);
+  Future<ApiResponse<void>> deleteNotification(int id);
+}

--- a/frontend/lib/core/di/service_locator.dart
+++ b/frontend/lib/core/di/service_locator.dart
@@ -1,0 +1,114 @@
+import '../api/api_client.dart';
+import '../api/services_interfaces.dart';
+import '../../api/services/user_service.dart';
+import '../../api/services/physiological_data_service.dart';
+import '../../api/services/anxiety_event_service.dart';
+import '../../api/services/session_service.dart';
+import '../../api/services/device_service.dart';
+import '../../api/services/notification_service.dart';
+
+/// Service Locator para gestionar las dependencias de la aplicación
+/// Aplica el principio de Inversión de Dependencias (DIP)
+/// Facilita las pruebas unitarias y el mantenimiento del código
+class ServiceLocator {
+  static final ServiceLocator _instance = ServiceLocator._internal();
+  factory ServiceLocator() => _instance;
+  ServiceLocator._internal();
+
+  late final ApiClient _apiClient;
+  late final IUserService _userService;
+  late final IPhysiologicalDataService _physiologicalDataService;
+  late final IAnxietyEventService _anxietyEventService;
+  late final ISessionService _sessionService;
+  late final IDeviceService _deviceService;
+  late final INotificationService _notificationService;
+
+  bool _initialized = false;
+
+  /// Inicializa todas las dependencias de la aplicación
+  void initialize() {
+    if (_initialized) return;
+
+    // Inicializar cliente API
+    _apiClient = ApiClient();
+
+    // Inicializar servicios con inyección de dependencias
+    _userService = UserService(_apiClient);
+    _physiologicalDataService = PhysiologicalDataService(_apiClient);
+    _anxietyEventService = AnxietyEventService(_apiClient);
+    _sessionService = SessionService(_apiClient);
+    _deviceService = DeviceService(_apiClient);
+    _notificationService = NotificationService(_apiClient);
+
+    _initialized = true;
+  }
+
+  /// Obtiene el cliente API
+  ApiClient get apiClient {
+    _ensureInitialized();
+    return _apiClient;
+  }
+
+  /// Obtiene el servicio de usuarios
+  IUserService get userService {
+    _ensureInitialized();
+    return _userService;
+  }
+
+  /// Obtiene el servicio de datos fisiológicos
+  IPhysiologicalDataService get physiologicalDataService {
+    _ensureInitialized();
+    return _physiologicalDataService;
+  }
+
+  /// Obtiene el servicio de eventos de ansiedad
+  IAnxietyEventService get anxietyEventService {
+    _ensureInitialized();
+    return _anxietyEventService;
+  }
+
+  /// Obtiene el servicio de sesiones
+  ISessionService get sessionService {
+    _ensureInitialized();
+    return _sessionService;
+  }
+
+  /// Obtiene el servicio de dispositivos
+  IDeviceService get deviceService {
+    _ensureInitialized();
+    return _deviceService;
+  }
+
+  /// Obtiene el servicio de notificaciones
+  INotificationService get notificationService {
+    _ensureInitialized();
+    return _notificationService;
+  }
+
+  /// Actualiza el token de autenticación en todos los servicios
+  void updateAuthToken(String token) {
+    _ensureInitialized();
+    _apiClient.updateAuthToken(token);
+  }
+
+  /// Remueve el token de autenticación
+  void removeAuthToken() {
+    _ensureInitialized();
+    _apiClient.removeAuthToken();
+  }
+
+  /// Verifica que el ServiceLocator esté inicializado
+  void _ensureInitialized() {
+    if (!_initialized) {
+      throw StateError(
+        'ServiceLocator no ha sido inicializado. '
+        'Llama a ServiceLocator().initialize() antes de usar los servicios.',
+      );
+    }
+  }
+
+  /// Resetea el ServiceLocator (útil para pruebas)
+  void reset() {
+    _initialized = false;
+  }
+}

--- a/frontend/lib/models/administrador/administrador.dart
+++ b/frontend/lib/models/administrador/administrador.dart
@@ -1,0 +1,22 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'administrador.freezed.dart';
+part 'administrador.g.dart';
+
+@freezed
+abstract class Administrador with _$Administrador {
+  const factory Administrador({
+    required int id,
+    @JsonKey(name: 'institucion_id')
+    required int institucionId,
+    required String nombre,
+    required String apellido,
+    required String email,
+    required String rol,
+    required bool activo,
+    @JsonKey(name: 'ultimo_acceso')
+    required DateTime ultimoAcceso,
+  }) = _Administrador;
+
+  factory Administrador.fromJson(Map<String, dynamic> json) => _$AdministradorFromJson(json);
+}

--- a/frontend/lib/models/aggregated_report/aggregated_report.dart
+++ b/frontend/lib/models/aggregated_report/aggregated_report.dart
@@ -1,0 +1,36 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'aggregated_report.freezed.dart';
+part 'aggregated_report.g.dart';
+
+@freezed
+abstract class AggregatedReport with _$AggregatedReport {
+  const factory AggregatedReport({
+    required int id,
+    @JsonKey(name: 'institucion_id')
+    required int institucionId,
+    @JsonKey(name: 'grupo_id')
+    int? grupoId,
+    @JsonKey(name: 'fecha_reporte')
+    required DateTime fechaReporte,
+    required String periodo,
+    @JsonKey(name: 'total_usuarios')
+    required int totalUsuarios,
+    @JsonKey(name: 'total_eventos')
+    required int totalEventos,
+    @JsonKey(name: 'promedio_bpm')
+    required double promedioBpm,
+    @JsonKey(name: 'promedio_spo2')
+    required double promedioSpo2,
+    @JsonKey(name: 'promedio_temperatura')
+    required double promedioTemperatura,
+    @JsonKey(name: 'eventos_por_nivel')
+    required Map<String, dynamic> eventosPorNivel,
+    @JsonKey(name: 'horas_pico')
+    required Map<String, dynamic> horasPico,
+    @JsonKey(name: 'datos_agregados')
+    required Map<String, dynamic> datosAgregados,
+  }) = _AggregatedReport;
+
+  factory AggregatedReport.fromJson(Map<String, dynamic> json) => _$AggregatedReportFromJson(json);
+}

--- a/frontend/lib/models/anxiety_event/anxiety_event.dart
+++ b/frontend/lib/models/anxiety_event/anxiety_event.dart
@@ -1,0 +1,37 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'anxiety_event.freezed.dart';
+part 'anxiety_event.g.dart';
+
+enum AnxietyLevel { LOW, MEDIUM, HIGH }
+
+@freezed
+abstract class AnxietyEvent with _$AnxietyEvent {
+  const factory AnxietyEvent({
+    required int id,
+    @JsonKey(name: 'usuario_id')
+    required int usuarioId,
+    @JsonKey(name: 'sesion_id')
+    required int sesionId,
+    required DateTime timestamp,
+    @JsonKey(name: 'nivel_ansiedad')
+    required AnxietyLevel nivelAnsiedad,
+    @JsonKey(name: 'bpm_momento')
+    required int bpmMomento,
+    @JsonKey(name: 'spo2_momento')
+    required int spo2Momento,
+    @JsonKey(name: 'temperatura_momento')
+    required double temperaturaMomento,
+    @JsonKey(name: 'duracion_minutos')
+    required int duracionMinutos,
+    @JsonKey(name: 'factores_detectados')
+    required Map<String, dynamic> factoresDetectados,
+    @JsonKey(name: 'accion_tomada')
+    required String accionTomada,
+    required bool resuelto,
+    @JsonKey(name: 'notas_usuario')
+    required String notasUsuario,
+  }) = _AnxietyEvent;
+
+  factory AnxietyEvent.fromJson(Map<String, dynamic> json) => _$AnxietyEventFromJson(json);
+}

--- a/frontend/lib/models/configuracion_grupo/config_grupo.dart
+++ b/frontend/lib/models/configuracion_grupo/config_grupo.dart
@@ -1,0 +1,33 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'config_grupo.freezed.dart';
+part 'config_grupo.g.dart';
+
+@freezed
+abstract class ConfigGrupo with _$ConfigGrupo {
+  const factory ConfigGrupo({
+    required int id,
+    @JsonKey(name: 'grupo_id')
+    required int grupoId,
+    @JsonKey(name: 'umbral_bpm_min')
+    required int umbralBpmMin,
+    @JsonKey(name: 'umbral_bpm_max')
+    required int umbralBpmMax,
+    @JsonKey(name: 'umbral_spo2_min')
+    required int umbralSpo2Min,
+    @JsonKey(name: 'umbral_spo2_max')
+    required int umbralSpo2Max,
+    @JsonKey(name: 'umbral_temp_min')
+    required double umbralTempMin,
+    @JsonKey(name: 'umbral_temp_max')
+    required double umbralTempMax,
+    @JsonKey(name: 'intervalo_medicion')
+    required int intervaloMedicion,
+    @JsonKey(name: 'notificaciones_activas')
+    required bool notificacionesActivas,
+    @JsonKey(name: 'configuracion_avanzada')
+    required bool configuracionAvanzada,
+  }) = _ConfigGrupo;
+
+  factory ConfigGrupo.fromJson(Map<String, dynamic> json) => _$ConfigGrupoFromJson(json);
+}

--- a/frontend/lib/models/configuracion_user/config_user.dart
+++ b/frontend/lib/models/configuracion_user/config_user.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'config_user.freezed.dart';
+part 'config_user.g.dart';
+
+@freezed
+abstract class ConfigUser with _$ConfigUser {
+  const factory ConfigUser({
+    required int id,
+    @JsonKey(name: 'usuario_id')
+    required int userId,
+    @JsonKey(name: 'notificaciones_push')
+    required bool notificacionesPush,
+    @JsonKey(name: 'notificaciones_email')
+    required bool notificacionesEmail,
+    @JsonKey(name: 'umbral_personalizado_bpm')
+    required int umbralPersonalizadoBpm,
+    @JsonKey(name: 'umbral_personalizado_spo2')
+    required int umbralPersonalizadoSpo2,
+    @JsonKey(name: 'umbral_personalizado_temp')
+    required double umbralPersonalizadoTemp,
+    @JsonKey(name: 'modo_privado')
+    required bool modoPrivado,
+    @JsonKey(name: 'compartir_datos_investigacion')
+    required bool compartirDatosInvestigacion,
+    @JsonKey(name: 'configuracion_avanzada')
+    required Object configuracionAvanzada,
+  }) = _ConfigUser;
+
+  factory ConfigUser.fromJson(Map<String, dynamic> json) => _$ConfigUserFromJson(json);
+}

--- a/frontend/lib/models/data_export/data_export.dart
+++ b/frontend/lib/models/data_export/data_export.dart
@@ -1,0 +1,33 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'data_export.freezed.dart';
+part 'data_export.g.dart';
+
+enum TipoDatos { FULL, SUMMARY }
+enum FormatoExport { CSV, JSON, XLSX }
+enum EstadoExport { PENDING, READY, FAILED }
+
+@freezed
+abstract class DataExport with _$DataExport {
+  const factory DataExport({
+    required int id,
+    @JsonKey(name: 'usuario_id')
+    required int usuarioId,
+    @JsonKey(name: 'fecha_solicitud')
+    required DateTime fechaSolicitud,
+    @JsonKey(name: 'fecha_desde')
+    required DateTime fechaDesde,
+    @JsonKey(name: 'fecha_hasta')
+    required DateTime fechaHasta,
+    @JsonKey(name: 'tipo_datos')
+    required TipoDatos tipoDatos,
+    required FormatoExport formato,
+    required EstadoExport estado,
+    @JsonKey(name: 'url_descarga')
+    String? urlDescarga,
+    @JsonKey(name: 'fecha_expiracion')
+    DateTime? fechaExpiracion,
+  }) = _DataExport;
+
+  factory DataExport.fromJson(Map<String, dynamic> json) => _$DataExportFromJson(json);
+}

--- a/frontend/lib/models/dispositivo/dispositivo.dart
+++ b/frontend/lib/models/dispositivo/dispositivo.dart
@@ -1,0 +1,33 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'dispositivo.freezed.dart';
+part 'dispositivo.g.dart';
+
+@freezed
+abstract class Dispositivo with _$Dispositivo {
+  const factory Dispositivo({
+    required int id,
+    @JsonKey(name: 'device_id')
+    required String deviceId,
+    @JsonKey(name: 'numero_serie')
+    required String numeroSerie,
+    required String modelo,
+    @JsonKey(name: 'api_key_iot')
+    required String apiKeyIot,
+    @JsonKey(name: 'fecha_fabricacion')
+    required DateTime fechaFabricacion,
+    @JsonKey(name: 'fecha_activacion')
+    required DateTime fechaActivacion,
+    required String estado,
+    @JsonKey(name: 'version_firmware')
+    required String versionFirmware,
+    @JsonKey(name: 'configuracion_hardware')
+    required Object configuracionHardware,
+    @JsonKey(name: 'created_at')
+    required DateTime createdAt,
+    @JsonKey(name: 'institucion_id')
+    int? institucionId
+  }) = _Dispositivo;
+
+  factory Dispositivo.fromJson(Map<String, dynamic> json) => _$DispositivoFromJson(json);
+}

--- a/frontend/lib/models/grupo/grupo.dart
+++ b/frontend/lib/models/grupo/grupo.dart
@@ -1,0 +1,22 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'grupo.freezed.dart';
+part 'grupo.g.dart';
+
+@freezed
+abstract class Grupo with _$Grupo{
+  const factory Grupo({
+    required int id,
+    @JsonKey(name: 'institucion_id')
+    required int institucionId,
+    required String nombre,
+    required String descripcion,
+    @JsonKey(name: 'codigo_activacion')
+    required String codigoActivacion,
+    required bool activo,
+    @JsonKey(name: 'created_at')
+    required DateTime createdAt,
+  }) = _Grupo;
+
+  factory Grupo.fromJson(Map<String, dynamic> json) => _$GrupoFromJson(json);
+}

--- a/frontend/lib/models/institucion/institucion.dart
+++ b/frontend/lib/models/institucion/institucion.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'institucion.freezed.dart';
+part 'institucion.g.dart';
+
+@freezed
+abstract class Institucion with _$Institucion{
+  const factory Institucion({
+    required int id,
+    required String nombre,
+    required String direccion,
+    required String telefono,
+    required String email,
+    @JsonKey(name: 'fecha_registro')
+    required DateTime fechaRegistro,
+    required bool activo,
+  }) = _Institucion;
+
+  factory Institucion.fromJson(Map<String, dynamic> json) => _$InstitucionFromJson(json);
+}

--- a/frontend/lib/models/notification/notification_model.dart
+++ b/frontend/lib/models/notification/notification_model.dart
@@ -1,0 +1,34 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'notification_model.freezed.dart';
+part 'notification_model.g.dart';
+
+enum NotificationType { 
+  ANXIETY_ALERT, 
+  RECOMMENDATION_BREATHING, 
+  RECOMMENDATION_BREAK, 
+  SYSTEM_MESSAGE 
+}
+
+enum MetodoEnvio { PUSH, EMAIL }
+
+@freezed
+abstract class NotificationModel with _$NotificationModel {
+  const factory NotificationModel({
+    required int id,
+    @JsonKey(name: 'usuario_id')
+    required int usuarioId,
+    @JsonKey(name: 'evento_ansiedad_id')
+    int? eventoAnsiedadId,
+    required NotificationType tipo,
+    required String titulo,
+    required String mensaje,
+    required DateTime timestamp,
+    required bool leida,
+    required bool enviada,
+    @JsonKey(name: 'metodo_envio')
+    required MetodoEnvio metodoEnvio,
+  }) = _NotificationModel;
+
+  factory NotificationModel.fromJson(Map<String, dynamic> json) => _$NotificationModelFromJson(json);
+}

--- a/frontend/lib/models/physiological_data/physiological_data.dart
+++ b/frontend/lib/models/physiological_data/physiological_data.dart
@@ -1,0 +1,25 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'physiological_data.freezed.dart';
+part 'physiological_data.g.dart';
+
+@freezed
+abstract class PhysiologicalData with _$PhysiologicalData {
+  const factory PhysiologicalData({
+    required int id,
+    @JsonKey(name: 'sesion_id')
+    required int sesionId,
+    @JsonKey(name: 'usuario_id')
+    required int usuarioId,
+    @JsonKey(name: 'pulsera_id')
+    required int pulseraId,
+    required DateTime timestamp,
+    required int bpm,
+    required int spo2,
+    required double temperatura,
+    @JsonKey(name: 'calidad_senal')
+    required int calidadSenal,
+  }) = _PhysiologicalData;
+
+  factory PhysiologicalData.fromJson(Map<String, dynamic> json) => _$PhysiologicalDataFromJson(json);
+}

--- a/frontend/lib/models/session/session.dart
+++ b/frontend/lib/models/session/session.dart
@@ -1,0 +1,29 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'session.freezed.dart';
+part 'session.g.dart';
+
+@freezed
+abstract class Session with _$Session {
+  const factory Session({
+    required int id,
+    @JsonKey(name: 'usuario_id')
+    required int usuarioId,
+    @JsonKey(name: 'pulsera_id')
+    required int pulseraId,
+    @JsonKey(name: 'fecha_inicio')
+    required DateTime fechaInicio,
+    @JsonKey(name: 'fecha_fin')
+    DateTime? fechaFin,
+    @JsonKey(name: 'duracion_minutos')
+    required int duracionMinutos,
+    required String estado,
+    @JsonKey(name: 'ubicacion_lat')
+    required double ubicacionLat,
+    @JsonKey(name: 'ubicacion_lng')
+    required double ubicacionLng,
+    required String notas,
+  }) = _Session;
+
+  factory Session.fromJson(Map<String, dynamic> json) => _$SessionFromJson(json);
+}

--- a/frontend/lib/models/system_log/system_log.dart
+++ b/frontend/lib/models/system_log/system_log.dart
@@ -1,0 +1,27 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'system_log.freezed.dart';
+part 'system_log.g.dart';
+
+@freezed
+abstract class SystemLog with _$SystemLog {
+  const factory SystemLog({
+    required int id,
+    @JsonKey(name: 'usuario_id')
+    int? usuarioId,
+    @JsonKey(name: 'pulsera_id')
+    int? pulseraId,
+    @JsonKey(name: 'tipo_evento')
+    required String tipoEvento,
+    required String descripcion,
+    @JsonKey(name: 'ip_address')
+    required String ipAddress,
+    @JsonKey(name: 'user_agent')
+    required String userAgent,
+    @JsonKey(name: 'datos_adicionales')
+    required Map<String, dynamic> datosAdicionales,
+    required DateTime timestamp,
+  }) = _SystemLog;
+
+  factory SystemLog.fromJson(Map<String, dynamic> json) => _$SystemLogFromJson(json);
+}

--- a/frontend/lib/models/user/user.dart
+++ b/frontend/lib/models/user/user.dart
@@ -10,9 +10,23 @@ abstract class User with _$User {
     required String email,
     required String nombre,
     required String apellido,
+    @JsonKey(name: 'fecha_nacimiento')
+    required DateTime fechaNacimiento,
+    required String genero,
+    required String telefono,
     @JsonKey(name: 'tipo_usuario')
     required String tipoUsuario,
+    @JsonKey(name: 'consentimiento_datos')
+    required bool consentimientoDatos,
     required bool activo,
+    @JsonKey(name: 'created_at')
+    required DateTime createdAt,
+    @JsonKey(name: 'institucion_id')
+    int? institucionId,
+    @JsonKey(name: 'grupo_id')
+    int? grupoId,
+    @JsonKey(name: 'pulsera_id')
+    int? pulseraId,
   }) = _User;
 
   factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);

--- a/frontend/lib/models/user/user.dart
+++ b/frontend/lib/models/user/user.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user.freezed.dart';
+part 'user.g.dart';
+
+@freezed
+abstract class User with _$User {
+  const factory User({
+    required int id,
+    required String email,
+    required String nombre,
+    required String apellido,
+    @JsonKey(name: 'tipo_usuario')
+    required String tipoUsuario,
+    required bool activo,
+  }) = _User;
+
+  factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
+}


### PR DESCRIPTION
This pull request introduces several changes to the frontend codebase, focusing on improving API service implementations, organizing exports, and refining code analysis settings. The most significant updates include the addition of multiple API service classes for handling specific entities, the centralization of exports in the `api.dart` file, and adjustments to the analysis configuration to exclude generated files.

### API Service Implementations:
* **`frontend/lib/api/services/anxiety_event_service.dart`**: Added `AnxietyEventService` for managing anxiety events, including CRUD operations and functionality to mark events as resolved.
* **`frontend/lib/api/services/device_service.dart`**: Added `DeviceService` to handle device-related operations such as assignment, unassignment, and status retrieval.
* **`frontend/lib/api/services/notification_service.dart`**: Added `NotificationService` for managing notifications, including marking as read and bulk updates.
* **`frontend/lib/api/services/physiological_data_service.dart`**: Added `PhysiologicalDataService` for handling physiological data and retrieving statistics or time-series data.
* **`frontend/lib/api/services/session_service.dart`**: Added `SessionService` for session management, including active session retrieval and session termination.

### Code Organization:
* **`frontend/lib/api/api.dart`**: Centralized exports for core API utilities, services, models, and dependency injection, enhancing code readability and maintainability.

### Code Analysis Configuration:
* **`frontend/analysis_options.yaml`**: Updated the analyzer settings to exclude generated files (`*.g.dart` and `*.freezed.dart`) from analysis and ignore `invalid_annotation_target` errors.

### Git Ignore Updates:
* **`frontend/.gitignore`**: Added rules to ignore generated files (`*.g.dart` and `*.freezed.dart`) for better repository hygiene.